### PR TITLE
updating sample plugins to the modern era

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Custom Plugins
---------------
+## Custom Plugins
 
 A repository for customer built plugins, based off the included template
 
@@ -7,87 +6,75 @@ Non-Developers are welcome to start a new plugin by creating a folder for it, an
 
 Our development team will be glad to step in and start making the plugin a reality.
 
-Plugins can be written in any language natively supported by OS X including Python, BASH, SH, TSH and pearl to name a few
+Plugins can be written in any language natively supported by OS X including Python, bash, sh, zsh and pearl to name a few
 
 Plugins will run as root - With great power comes great responsibilities.
 
-Overview of a Plugin's Operation
---------------
+#### Overview of a Plugin's Operation
+
+Each plugin requires at least 2 files to function, optionally more:
+- *pluginname*.plugin - The actual plugin code to executed. Can be any binary executable or interpreted language script (bash, Python, zsh, etc). This file will live in `/Library/MonitoringClient/Plugins`.
+- *pluginname*.plist - A plist file with some required data for the Watchman agent to be able to run the plugin. This file also lives in `/Library/MonitoringClient/Plugins`. There are some optional keys (discussed later in this document) but the keys required in this plist are:
+  - `PluginName` - The user friendly name of the PluginName.
+  - `PluginSlug` - The sluggified (no URL illegal characters) version of the plugin name.
+  - `PluginUUID` - UUID used to identify the plugin to the server. Watchman Monitoring will provide and register one on request.
+  - `ProgramArguments` - File name of the plugin to run. Assumes the path of `/Library/MonitoringClient/Plugins/`.
+- *pluginname*_settings.plist - (Optional) Plist that can contain settings/data specific to the plugin's operation, any data the plugin needs to save. This file lives in `/Library/MonitoringClient/PluginSupport` and the plugin code should generate it if/when it doesn't exist with any default settings/data.
 
 An effective plugin needs to perform 3 Major tasks:
-* Do some work! (Python, Bash, etc)
-* Print some output. (stdout please)
-* Exit with an appropriate status (0, 2, 20 details below)
+* Do some work to determine if any kind of condition worth reporting to the dashboard exists.
+* Print some output to `stdout`.
+* Exit with an appropriate status (0, 2, 20, 25, 200, details below).
 
 On each run of the monitoring client, the plugins folder is enumerated, and each plugin with a valid plist is run.
 
-The Monitoring Client reads the output (stdout) of each plugin, and includes this text, as well as the exit status, to the Watchman Monitoring server.
-
-The plugin's architect uses the exit status to the server know the severity of the report.
+The Monitoring Client reads the output (`stdout`) of each plugin, and includes this text, as well as the exit status, to the Watchman Monitoring server. The plugin's architect uses the exit status to let the server know the severity of the report.
 
 
-Exit Status and the Watchman Monitoring server 
---------------
+#### Exit Status and the Watchman Monitoring server
 
 The server will act according to how a plugin reports and exits.  The following exit statuses are used:
 
-* *0* - We're All Good = Information will be displayed at the server, but not emailed.
-* *2* - Big Problem! = This information will be displayed on the server, and trigger an email.
+* *0* - We're All Good = Information will be displayed at the server, but no alert or email will be sent.
+* *2* - Big Problem! = This information will be displayed on the server, and trigger a single email until the error is resolved.
 * *20* - Information worth reporting was found, but no email should be sent.
-* *200* - A one-time Alert = This is an event you need to know about. An email will be sent, even amongst other repeating errors
-* *25* - Nothing to see here = Information will not be sent to the server (and not emailed)
-* 
-_A future version of the server will gather & display messages sent with status 20._
+* *200* - A one-time Alert = This is an event you need to know about whenever it is detected. An email will be sent, even amongst other repeating errors.
+* *25* - Nothing to see here = No information will be sent to the server.
 
-_If a plugin's exit status is 1, the warning will be reported to the Watchman Monitoring staff, for inspection of the plugin's failure._
+_If a plugin's exit status is 1, that is considered a failure state for the plugin itself. A warning will be reported to the Watchman Monitoring staff for inspection of the plugin's failure._
 
-
-All custom plugins must begin with an underscore _ (i.e. _check_for_variable.plugin)
-
-A private repository is available as well.
-https://github.com/watchmanmonitoring/subscriberplugins (Github will show a 404 on that page unless you have access. Access is granted by contacting [Watchman Monitoring support](https://support.watchmanmonitoring.com/hc/requests/new).
+Plugins should be maintained in the authors own github repo, which Watchman Monitoring will need to be granted access to.
 
 
-Preference Pane Options
---------------
+## Preference Pane Options
 
 Each plugin has the ability to provide options to be displayed in the Preference Pane.
 
 
-h1. Creating PreferencePane options
+#### Creating PreferencePane options
 
-The vast majority of our plugins require no user interaction in order to be effective.
+The vast majority of our plugins require no user interaction in order to be effective. There are cases where the ability to set an option is needed. We've solved this by adding the ability to define custom fields in our PreferencePane
 
-There are cases where the ability to set an option is needed. We've solved this by adding the ability to define custom fields in our PreferencePane
+The PreferencePane supports an Array named PluginOptions in the Plugins plist, which can contain a number of Dictionary entries. Each entry will be presented within the PreferencePane, so long as the dictionary contains the follow 5 keys as defined below:
 
-The PreferencePane support an Array named PluginOptions, which can contain a number of Dictionary entries.
+**SettingStorageKey:**
+	The exact name of key which the key that PreferencePane will reference in the Plugin settings plist. Will be created if it doesn't exist.
 
-Each entry will be presented within the PreferencePane, so long as the dictionary contains the follow 5 keys as defined below
+**SettingStoragePath:**
+  Full path to the settings plist. If the file doesn't exist, it will be created only if the path begins `/Library/MonitoringClient/PluginSupport`.
 
-*SettingStoragePath*
-  full path to the settings file in question
-	If the file doesn't exist, it will be created IF the path begins /Library/MonitoringClient
-		else do not display that GUI object
+**SettingTitle:**
+	Title of the object as displayed in the PreferencePane. Must be present or the GUI object won’t be displayed in the PreferencePane.
 
-*SettingStorageKey*
-	The exact name of key which the PreferencePane will save the file to.
-	Will be created if it didn’t exist
+**SettingTitleHint:**
+	Optional, displayed in smaller text in the PreferencePane object to describe functionality of this particular option.
 
-*SettingTitle*
-	Must be present or the gui option won’t be displayed in the PreferencePane
+**SettingType:**
+	A dictionary with two children keys: `Type` and `Value`
 
-*SettingTitleHint*
-	Optional, displayed in smaller text to describe functionality of this particular option.
+#### PluginOptions
 
-*SettingType*
-	A dictionary with two children keys:
-	Type
-	Value
-
-
-*PluginOptions*
-
-|Type|Value|Description|Stored as|
+|Type|Value|Description|Data Type|
 |------|-----|-----|----|
 |Checkbox|Positive or Negative|Positive = checked = true & set to false if not present Negative = checked = False, & set to true if not present (Positive is assumed)|bool|
 |FolderPicker|[ignored]|make this a “well”, so the end user has the option to drag & drop or click Select|string|
@@ -99,30 +86,20 @@ Each entry will be presented within the PreferencePane, so long as the dictionar
 |DisplayOnly|ignored|There will be no user options here. This will be used only to display the SettingTitle and/or Setting Hint|Empty|
 
 
-End-user Friendly Report
---------------
-At this time, the server keeps a `plugin.rb#L193` which contains a list of end-user friendly statements to describe a failure. These would be added to the public portion of a ticket.
-
-
-PreferencePane visibility
---------------
+## PreferencePane visibility
 
 There are some cases when a Plugin, or it's PreferencePane options, are needed, but not until certain requirements are met.
 
-Disabling a Plugin
---------------
+## Disabling a Plugin
 
-A plugin will be fully disabled when it's file name is added to 
+A plugin will be fully disabled when a boolean key titled `Plugin_Enabled` and set `false` in the plugin's _settings.plist file.
 
-/Library/MonitoringClient/ClientSettings.plist
-
-as an entry in the array _PluginsDisabled_
+If the `Plugin_Enabled` key is not present, it is assumed `true`.
 
 
-Disabling the Plugin's display option
---------------
+## Disabling the Plugin's display option
 
-We support a boolean key titled _PrefPaneVisibility_ in any given plugin's _settings.plist file.
+We support a boolean key titled `PrefPaneVisibility` in any given plugin's _settings.plist file.
 
 If this key is either missing or True, the plugin will be shown in the PreferencePane.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ## Custom Plugins
 
-A repository for customer built plugins, based off the included template
+A repository for customer built plugins, based off the included template.  
 
-Non-Developers are welcome to start a new plugin by creating a folder for it, and laying out a readme file with the goals.
+Non-Developers are welcome to start a new plugin by creating a folder for it, and laying out a readme file with the goals.  
 
-Our development team will be glad to step in and start making the plugin a reality.
+Our development team will be glad to step in and start making the plugin a reality.  
 
-Plugins can be written in any language natively supported by OS X including Python, bash, sh, zsh and pearl to name a few
+Plugins can be written in any language natively supported by OS X. Historically this has included Python, bash, sh, zsh, perl, etc.  
 
-Plugins will run as root - With great power comes great responsibilities.
+Plugins will run as root - With great power comes great responsibilities.  
 
 #### Overview of a Plugin's Operation
 
@@ -22,11 +22,12 @@ Each plugin requires at least 2 files to function, optionally more:
 - *pluginname*_settings.plist - (Optional) Plist that can contain settings/data specific to the plugin's operation, any data the plugin needs to save. This file lives in `/Library/MonitoringClient/PluginSupport` and the plugin code should generate it if/when it doesn't exist with any default settings/data.
 
 An effective plugin needs to perform 3 Major tasks:
+
 * Do some work to determine if any kind of condition worth reporting to the dashboard exists.
 * Print some output to `stdout`.
 * Exit with an appropriate status (0, 2, 20, 25, 200, details below).
 
-On each run of the monitoring client, the plugins folder is enumerated, and each plugin with a valid plist is run.
+On each hourly run, the Monitoring Client enumerates the candidates in the `Plugins` folder, and runs them in alphabetical order.
 
 The Monitoring Client reads the output (`stdout`) of each plugin, and includes this text, as well as the exit status, to the Watchman Monitoring server. The plugin's architect uses the exit status to let the server know the severity of the report.
 

--- a/base_python_sample/_base_python.plugin
+++ b/base_python_sample/_base_python.plugin
@@ -26,20 +26,21 @@ Exit Statuses:
 
 Some extra features are made available through the environment created
 by the client, such as logging and basic checks, through the
-PluginToolkit module.
+Toolkit module.
 
 For more detailed examples and specific purpose plugins (log scanning,
 command status, etc) please refer to another sample, or ask us to make
 one!
 '''
 import os, sys
-from PluginToolkit import *
+import Toolkit
+from Toolkit import Log
 
 ''' Troubleshooting and Logging
 Troubleshooting is a little bit easier when you know where to look.
 
-Our ClientLogging() is available through PluginToolkit.Log and as far
-as plugins go only has one real thing to call:
+Our ClientLogging() is available through Toolkit.Log and as far as
+plugins go only has one real thing to call:
 
   Log.write('Some helpful text.')
 
@@ -61,32 +62,32 @@ It's not uncommon to have to keep track of information, such as a
 timestamp or file size, or enable PrefPaneVisibility and provide some
 user-adjustable items.
 
-PluginToolkit.check_settings() provides an easy way to provide some
-defaults and verify existing settings.
+Toolkit.check_settings() provides an easy way to provide some defaults
+and verify existing settings.
 '''
-settings_plist = '/Library/MonitoringClient/PluginSupport/_base_python_settings.plist'
+settings_file = '/Library/MonitoringClient/PluginSupport/_base_python_settings.plist'
 base_settings = {
 	'Some_Setting'       : 'default string',
 	'Other_Settings'     : 6,
 	'PrefPaneVisibility' : True
 }
-settings = check_settings(base_settings, settings_plist)
+settings = Toolkit.check_settings(base_settings, settings_file)
 
 ''' Plist handling
 Plists can be a pain if you're not sure what you're going to run into
 (binary vs xml, etc), and there's no real clean way to check before
 trying to read it.
 
-PluginToolkit has some functions to mimick plistlib usage to help deal
-with whatever you might come across.  Specifically:
+Toolkit has some functions to mimick plistlib usage to help deal with
+whatever you might come across.  Specifically:
 
-  PluginToolkit.readPlist()
-  PluginToolkit.writePlist()
-  PluginToolkit.readPlistFromString()
-  PluginToolkit.writePlistToString()
+  Toolkit.readPlist()
+  Toolkit.writePlist()
+  Toolkit.readPlistFromString()
+  Toolkit.writePlistToString()
 '''
 app_plist = '/Library/App/Logs/Log.plist'
-app_data = readPlist(app_plist)
+app_data = Toolkit.readPlist(app_plist)
 
 ''' Notes
 It's also noteworthy that the plugin needs to be executable by root in
@@ -113,7 +114,7 @@ def main():
 
 	output += "Base Python Plugin Output!"
 	print(output)
-	sys.exit(e)
+	return e
 
 if __name__ == '__main__':
-	main()
+	sys.exit( main() )

--- a/build_url_sample/build_url_sample.plugin
+++ b/build_url_sample/build_url_sample.plugin
@@ -9,7 +9,9 @@ This plugin sample will attempt to lay out a way snatch information
 from the client to build a machine-specific URL.
 '''
 import os, sys
-from PluginToolkit import *
+from Toolkit import check_settings
+from Toolkit import write_settings
+from Toolkit import readPlist
 
 '''
 Pretty simple setup here, we're going to use a known key to ask for a
@@ -18,19 +20,19 @@ machine ID of some sort from an application's configuration plist.
 Settings-wise, we're holding the value of whatever we find, and will
 issue a warning if it changes.
 '''
-base_url       = 'http://www.myawesomeservice.com/machines.php?machine_id=%s'
-app_plist      = '/path/to/app.plist'
+base_url  = 'http://www.myawesomeservice.com/machines.php?machine_id=%s'
+app_plist = '/path/to/app.plist'
 
-settings_plist = '/Library/MonitoringClient/PluginSupport/_build_url_sample_settings.plist'
-base_settings  = {
+settings_file = '/Library/MonitoringClient/PluginSupport/_build_url_sample_settings.plist'
+base_settings = {
 	'machine_id' : ''
 }
-settings       = check_settings(base_settings, settings_plist)
+settings = check_settings(base_settings, settings_file)
 
 def main():
 	e = 0
 	if not os.path.exists(app_plist):
-		sys.exit(25)
+		return 25
 	app_data = readPlist(app_plist)
 	machine_id = app_data.get('machine_id', settings['machine_id'])
 
@@ -42,11 +44,11 @@ def main():
 		e = 2
 
 	settings['machine_id'] = machine_id
-	writePlist(settings, settings_plist)
+	write_settings(settings, settings_file)
 
 	machine_url = base_url % machine_id
 	print('Machine URL: %s' % machine_url)
-	sys.exit(e)
+	return e
 
 if __name__ == '__main__':
-	main()
+	sys.exit( main() )

--- a/log_scan_sample/log_scan_sample.plugin
+++ b/log_scan_sample/log_scan_sample.plugin
@@ -11,7 +11,10 @@ You will need to specify some basic information, such as the path to the log and
 and a list of bad words to look for inside the log.
 '''
 import os, sys
-from PluginToolkit import *
+from Toolkit import Log
+from Toolkit import check_settings
+from Toolkit import write_settings
+from LogScanner import LogScanner
 
 ''' Settings
 The list of logs to check will be looped through later.  It's of the
@@ -35,11 +38,11 @@ basic, it's just:
   Logs:
     log path -> log size
 '''
-settings_plist = '/Library/MonitoringClient/PluginSupport/_log_scan_sample_settings.plist'
+settings_file = '/Library/MonitoringClient/PluginSupport/_log_scan_sample_settings.plist'
 base_settings = {
 	'Logs': {}
 }
-settings = check_settings(base_settings, settings_plist)
+settings = check_settings(base_settings, settings_file)
 
 ''' Main
 The LogScanner() class tries to keep this as simple as possible, but
@@ -49,7 +52,7 @@ the settings outlined above.
 Obviously this outline will use the formats provided in these settings,
 but feel free to do whatever works for you.
 
-Basic usage of PluginToolkit.LogScanner() is as follows:
+Basic usage of LogScanner() is as follows:
 
 # Load it up
 scanner = LogScanner()
@@ -122,14 +125,14 @@ def main():
 		)
 		status_list.append(scanner.e)
 
-	writePlist(settings, settings_plist)
+	write_settings(settings, settings_file)
 	print(output)
 
-	if output == '': sys.exit(25)
-	elif status_list.count(200): sys.exit(200)
-	elif status_list.count(2): sys.exit(2)
-	elif status_list.count(20): sys.exit(20)
-	else: sys.exit(0)
+	if output == '': return 25
+	elif status_list.count(200): return 200
+	elif status_list.count(2): return 2
+	elif status_list.count(20): return 20
+	else: return 0
 
 if __name__ == '__main__':
-	main()
+	sys.exit( main() )

--- a/pref_pane_gui_items_example/prefpane_gui_example.plist
+++ b/pref_pane_gui_items_example/prefpane_gui_example.plist
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PluginName</key>
+	<string>Prefpane GUI Example</string>
+	<key>PluginSlug</key>
+	<string>prefpane_gui_example</string>
+	<key>PluginUUID</key>
+	<string>89ae7437-af6f-47f2-a585-757484c8ca65</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>prefpane_gui_example.plugin</string>
+	</array>
+	<key>PluginOptions</key>
+	<array>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>number_picker</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>A Number Picker Object</string>
+			<key>SettingTitleHint</key>
+			<string>String. Lets you pick from a range of numbers, ex: "0-10"</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>NumberPicker</string>
+				<key>Value</key>
+				<string>0-10</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>display_only</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>A DisplayOnly object</string>
+			<key>SettingTitleHint</key>
+			<string>String. Hint Text Here</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>DisplayOnly</string>
+				<key>Value</key>
+				<string></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>text_field</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>TextField</string>
+			<key>SettingTitleHint</key>
+			<string>String. A text entry field.</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>TextField</string>
+				<key>Value</key>
+				<string>140</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>checkbox_list</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>Checkboxes</string>
+			<key>SettingTitleHint</key>
+			<string>A list of checkboxes based from a settings dictionary.</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>Checkboxes</string>
+				<key>Value</key>
+				<string></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>checkbox_positive</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>Checkbox - Positive</string>
+			<key>SettingTitleHint</key>
+			<string>Bool. Checked == setting bool is true</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>Checkbox</string>
+				<key>Value</key>
+				<string>Positive</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>checkbox_negative</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>Checkbox - Positive</string>
+			<key>SettingTitleHint</key>
+			<string>Bool. Checked == setting bool is false</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>Checkbox</string>
+				<key>Value</key>
+				<string>Negative</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>username</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>Username</string>
+			<key>SettingTitleHint</key>
+			<string>String. A username field</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>UsernameField</string>
+				<key>Value</key>
+				<string>256</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>password</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>Password</string>
+			<key>SettingTitleHint</key>
+			<string>String. A password field, input obscured.</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>PasswordField</string>
+				<key>Value</key>
+				<string>256</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>popup</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>PopUpMenu</string>
+			<key>SettingTitleHint</key>
+			<string>String. A popup picker menu.</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>PopUpMenu</string>
+				<key>Value</key>
+				<array>
+					<string>Item 1</string>
+					<string>Item 2</string>
+					<string>Item 3</string>
+					<string>Item 4</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>file_picker</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>FilePicker</string>
+			<key>SettingTitleHint</key>
+			<string>String. A drag/drop or selection file picker.</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>FilePicker</string>
+				<key>Value</key>
+				<string></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>SettingStorageKey</key>
+			<string>folder_picker</string>
+			<key>SettingStoragePath</key>
+			<string>/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist</string>
+			<key>SettingTitle</key>
+			<string>FolderPicker</string>
+			<key>SettingTitleHint</key>
+			<string>String. A drag/drop or selection folder picker.</string>
+			<key>SettingType</key>
+			<dict>
+				<key>Type</key>
+				<string>FolderPicker</string>
+				<key>Value</key>
+				<string></string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/pref_pane_gui_items_example/prefpane_gui_example.plugin
+++ b/pref_pane_gui_items_example/prefpane_gui_example.plugin
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+###### Example plugin that constructs Pref Pane menu objects
+
+settingsFile="/Library/MonitoringClient/PluginSupport/prefpane_gui_example_settings.plist"
+
+## Write default values to settings plist if it's not there
+if [[ ! -f "$settingsFile" ]]; then
+	# number_picker
+	/usr/libexec/PlistBuddy -c "add :number_picker string '0'" "$settingsFile" 2>/dev/null
+	# text_field
+	/usr/libexec/PlistBuddy -c "add :text_field string 'Example Text'" "$settingsFile"
+	# checkbox_list
+	/usr/libexec/PlistBuddy -c "add :checkbox_list dict" \
+		-c "add :checkbox_list:ItemA bool true" \
+		-c "add :checkbox_list:ItemB bool false" \
+		-c "add :checkbox_list:ItemC bool false" \
+		"$settingsFile"
+	# checkbox_positive
+	/usr/libexec/PlistBuddy -c "add :checkbox_positive bool true" "$settingsFile"
+	# checkbox_negative
+	/usr/libexec/PlistBuddy -c "add :checkbox_negative bool true" "$settingsFile"
+	# username
+	/usr/libexec/PlistBuddy -c "add :username string 'Patrick Mahomes'" "$settingsFile"
+	# password
+	/usr/libexec/PlistBuddy -c "add :password string 'Run1tB@ck!!'" "$settingsFile"
+	# popup
+	/usr/libexec/PlistBuddy -c "add :popup string 'Item 1'" "$settingsFile"
+	# file_picker
+	/usr/libexec/PlistBuddy -c "add :file_picker string ''" "$settingsFile"
+	# folder_picker
+	/usr/libexec/PlistBuddy -c "add :folder_picker string ''" "$settingsFile"
+fi
+
+## Do work, read some values
+number_picker=$(/usr/libexec/PlistBuddy -c "print :number_picker" "$settingsFile")
+text_field=$(/usr/libexec/PlistBuddy -c "print :text_field" "$settingsFile")
+checkbox_list=$(/usr/libexec/PlistBuddy -c "print :checkbox_list" "$settingsFile")
+checkbox_positive=$(/usr/libexec/PlistBuddy -c "print :checkbox_positive" "$settingsFile")
+checkbox_negative=$(/usr/libexec/PlistBuddy -c "print :checkbox_negative" "$settingsFile")
+username=$(/usr/libexec/PlistBuddy -c "print :username" "$settingsFile")
+password=$(/usr/libexec/PlistBuddy -c "print :password" "$settingsFile")
+popup=$(/usr/libexec/PlistBuddy -c "print :popup" "$settingsFile")
+file_picker=$(/usr/libexec/PlistBuddy -c "print :file_picker" "$settingsFile")
+folder_picker=$(/usr/libexec/PlistBuddy -c "print :folder_picker" "$settingsFile")
+
+## Output some data for the dashboard
+echo "number_picker:  $number_picker"
+echo "text_field:  $text_field"
+echo "checkbox_list:  $checkbox_list"
+echo "checkbox_positive:  $checkbox_positive"
+echo "checkbox_negative:  $checkbox_negative"
+echo "username:  $username"
+echo "password:  $password"
+echo "popup:  $popup"
+echo "file_picker:  $file_picker"
+echo "folder_picker:  $folder_picker"
+
+## Exit something to tell the dashboard what to do
+exit 0

--- a/run_command_sample/run_command_sample.plugin
+++ b/run_command_sample/run_command_sample.plugin
@@ -5,13 +5,14 @@ Often times, we can rely on installed tools and services to provide the
 status of an application.
 
 This sample plugin will lay out how to use and what to expect from the
-run_cmd() function from PluginToolkit.
+run_cmd() function from Toolkit.
 
 Please refer to the basic python sample for information on plugin
 requirements.
 '''
 import sys
-from PluginToolkit import *
+from Toolkit import Log
+from Toolkit.run_cmd import run_cmd
 
 '''
 Commands can fail in many ways for countless reasons ... dealing with
@@ -41,11 +42,11 @@ def main():
 			output,
 			errors
 		))
-		sys.exit(1)
+		return 1
 
 	if output: print(output)
 	if errors: print(errors)
-	sys.exit(status)
+	return status
 
 if __name__ == '__main__':
-	main()
+	sys.exit( main() )


### PR DESCRIPTION
I took a glance at the documentation part of this, and none of it seemed _wrong_, but I didn't look that hard, this wasn't really for that.  Includes the moving of some stuff in https://github.com/watchmanmonitoring/client-mac/pull/2476

Updates the sample plugins code to match what's going on in the Toolkit these days.  So, mostly just a `PluginToolkit -> Toolkit` change, but modernized the `import`s and makes it a little less platform-specific as well.